### PR TITLE
Ignore Git LFS files to expedite shallow cloning

### DIFF
--- a/scripts/count-repo-lines
+++ b/scripts/count-repo-lines
@@ -33,7 +33,7 @@ mkdir -p "$workspace"
   cd "$workspace"
 
   if [[ ! -e "$repo_name" ]]; then
-    git clone --depth 1 "$url"
+    GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 "$url"
   fi
 
   (

--- a/scripts/count-repo-lines
+++ b/scripts/count-repo-lines
@@ -33,6 +33,9 @@ mkdir -p "$workspace"
   cd "$workspace"
 
   if [[ ! -e "$repo_name" ]]; then
+    # Since we do not care about revision history or
+    # Git Large File Storage files, we can shallow clone
+    # and ignore LFS pointers to expedite cloning.
     GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 "$url"
   fi
 

--- a/scripts/lang-stat
+++ b/scripts/lang-stat
@@ -81,6 +81,10 @@ handle_project() {
     rm -f inputs
     if [[ ! -d "$name" ]]; then
       echo "Clone '$name' from '$url'."
+
+      # Since we do not care about revision history or
+      # Git Large File Storage files, we can shallow clone
+      # and ignore LFS pointers to expedite cloning.
       GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 "$url" "$name"
     else
       echo "Use local git repo for '$name'."

--- a/scripts/lang-stat
+++ b/scripts/lang-stat
@@ -81,7 +81,7 @@ handle_project() {
     rm -f inputs
     if [[ ! -d "$name" ]]; then
       echo "Clone '$name' from '$url'."
-      git clone --depth 1 "$url" "$name"
+      GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 "$url" "$name"
     else
       echo "Use local git repo for '$name'."
       origin_url=$(git -C "$name" remote get-url origin)


### PR DESCRIPTION
When example repos for stats use Git LFS, git shallow clones still copy down all of the files. This causes unnecessary slowness and bandwidth usage. 

Considerations:
- This should not exclude any files we would want to analyze, since I doubt they would be in LFS in the first place.
- AFAIK, setting `GIT_LFS_SKIP_SMUDGE` will have no impact on users without Git LFS or repos that don't use LFS.
- This change may be too niche. If so, feel free to close this PR.

Variable documentation here:
https://github.com/git-lfs/git-lfs/commit/04d5a84ebb98fbcc039dfcf2486b1791d11b8daa#diff-c85f562ebea435a48d7cb903e03337076be751e0737e1d54cbaed233f4bd2b9cR325-R332