### PR TITLE
copy tree-sitter header to build dir

### DIFF
--- a/scripts/ocaml-tree-sitter-gen-ocaml
+++ b/scripts/ocaml-tree-sitter-gen-ocaml
@@ -213,6 +213,9 @@ CAMLprim value octs_create_parser_${lang_underscores}(value unit) {
 EOF
 
 cat > "$dst_dir"/lib/dune <<EOF
+; required to install tree_sitter/parser.h
+(include_subdirs qualified)
+
 (library
   (public_name $package.${lang_dashes})
   (name tree_sitter_${lang_underscores})
@@ -288,7 +291,7 @@ EOF
 # plugged into an existing git project without modifications.
 
 cat > "$dst_dir"/dune-project <<EOF
-(lang dune 2.0)
+(lang dune 3.7)
 (name tree-sitter-$lang)
 EOF
 


### PR DESCRIPTION
We should also copy the header file to the build dir when building language submodules.

context:
The recent Tree-sitter update no longer installs `parser.h` to the header installation location. Therefore, we need to utilize our local copy of `parser.h`. To achieve this, we should first copy it to the build directory under `_build`.

https://github.com/semgrep/semgrep/issues/9693

### Security

- [x] Change has no security implications (otherwise, ping the security team)
