### PR TITLE
Add options '--strip' and '--normalize'

### DIFF
--- a/src/gen/lib/To_JS.mli
+++ b/src/gen/lib/To_JS.mli
@@ -16,4 +16,5 @@
 val run :
   sort_choices:bool ->
   sort_rules:bool ->
+  strip:bool ->
   string option -> string option -> unit


### PR DESCRIPTION
This facilitates the comparison of two versions of the same grammar.

test plan:
```
$ make && make install
$ ocaml-tree-sitter to-js --normalize ~/tree-sitter-c-sharp/src/grammar.json
```
... and check that the JS output doesn't contain constructs that don't affect the types in CST.ml such as `field()`, `alias()`, `prec()`, etc.

I'm using this for the C# upgrade. There will be a PR in ocaml-tree-sitter-semgrep with an example.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
