### PR TITLE
remove opam build and install steps

### DIFF
--- a/tree-sitter.opam
+++ b/tree-sitter.opam
@@ -7,11 +7,9 @@ dev-repo: "git+https://github.com/returntocorp/ocaml-tree-sitter.git"
 license: "LGPL-2.1"
 
 build: [
-  ["./configure"]
-  [make]
 ]
 
-install: [make "install"]
+install: []
 
 depends: [
   "alcotest"


### PR DESCRIPTION
See semgrep/semgrep-proprietary#3136, but tldr this is needed so we can automatically pull deps from this opam file.

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
