### PR TITLE
Fix use of GNU old-style field designator extension

### DIFF
--- a/src/bindings/lib/bindings.c
+++ b/src/bindings/lib/bindings.c
@@ -52,21 +52,33 @@ static void finalize_tree(value v) {
 }
 
 static struct custom_operations tree_custom_ops = {
-  identifier : "tree handling",
-  finalize : finalize_tree,
-  compare : custom_compare_default,
-  hash : custom_hash_default,
-  serialize : custom_serialize_default,
-  deserialize : custom_deserialize_default
+  .identifier = "tree handling",
+  .finalize = finalize_tree,
+  .compare = custom_compare_default,
+  .hash = custom_hash_default,
+  .serialize = custom_serialize_default,
+  .deserialize = custom_deserialize_default,
+#ifdef custom_compare_ext_default
+  .compare_ext = custom_compare_ext_default,
+#endif
+#ifdef custom_fixed_length_default
+  .fixed_length = custom_fixed_length_default,
+#endif
 };
 
 static struct custom_operations TSNode_custom_ops = {
-  identifier : "TSNode handling",
-  finalize : custom_finalize_default,
-  compare : custom_compare_default,
-  hash : custom_hash_default,
-  serialize : custom_serialize_default,
-  deserialize : custom_deserialize_default
+  .identifier = "TSNode handling",
+  .finalize = custom_finalize_default,
+  .compare = custom_compare_default,
+  .hash = custom_hash_default,
+  .serialize = custom_serialize_default,
+  .deserialize = custom_deserialize_default,
+#ifdef custom_compare_ext_default
+  .compare_ext = custom_compare_ext_default,
+#endif
+#ifdef custom_fixed_length_default
+  .fixed_length = custom_fixed_length_default,
+#endif
 };
 
 const char *octs_read(void *payload, uint32_t byte_offset, TSPoint position,


### PR DESCRIPTION
    bindings.c:55:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
      identifier : "tree handling",
      ^~~~~~~~~~~~
      .identifier =

### Security

- [x] Change has no security implications (otherwise, ping the security team)
