### PR TITLE
Remove mutable global 'debug' from the generated 'Parse' modules

### DIFF
--- a/src/gen/lib/Codegen_parse.ml
+++ b/src/gen/lib/Codegen_parse.ml
@@ -40,9 +40,6 @@ val file :
   string ->
   (CST.%s, CST.extra) Tree_sitter_run.Parsing_result.t
 
-(** Whether to print debugging information. Default: false. *)
-val debug : bool ref
-
 (** The original tree-sitter parser. *)
 val ts_parser : Tree_sitter_bindings.Tree_sitter_API.ts_parser
 
@@ -78,8 +75,6 @@ let constant_header = "\
 
 open Tree_sitter_bindings
 open Tree_sitter_run
-
-let debug = ref false
 
 type mt = Run.matcher_token
 "


### PR DESCRIPTION
This `Parse.debug` variable is unused and not useful. It causes concerns due the possibility of sharing a global mutable state. It's best to remove this concern by removing this variable.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
