### PR TITLE
fix(multicore): remove shared state from template

### DIFF
--- a/src/gen/lib/Codegen_parse.ml
+++ b/src/gen/lib/Codegen_parse.ml
@@ -40,9 +40,6 @@ val file :
   string ->
   (CST.%s, CST.extra) Tree_sitter_run.Parsing_result.t
 
-(** The original tree-sitter parser. *)
-val ts_parser : Tree_sitter_bindings.Tree_sitter_API.ts_parser
-
 (** Parse a program into a tree-sitter CST. *)
 val parse_source_string :
    ?src_file:string -> string -> Tree_sitter_run.Tree_sitter_parsing.t
@@ -83,12 +80,12 @@ let declare_externals lang = sprintf "\
 external create_parser :
   unit -> Tree_sitter_API.ts_parser = \"octs_create_parser_%s\"
 
-let ts_parser = create_parser ()
-
 let parse_source_string ?src_file contents =
+  let ts_parser = create_parser () in
   Tree_sitter_parsing.parse_source_string ?src_file ts_parser contents
 
 let parse_source_file src_file =
+  let ts_parser = create_parser () in
   Tree_sitter_parsing.parse_source_file ts_parser src_file
 "
     lang


### PR DESCRIPTION
Currently when we generate a parser, we create a single global `ts_parser` and share it throughout the life of the parser; this isn't compatible with multithreaded applications that could use the same language parser between two different threads. This PR attempts to address this by making these parser creations local.

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
