### PR TITLE
fix: build with Windows native symlinks

### DIFF
--- a/scripts/download-tree-sitter
+++ b/scripts/download-tree-sitter
@@ -55,7 +55,8 @@ mkdir -p downloads
     rm -rf "$src_dir"
   fi
 
-  if [[ -d "$src_dir" ]]; then
+  # exists and non-empty
+  if [[ -d "$src_dir" && -n "$(ls -A "$src_dir")" ]]; then
     cat <<EOF
 Re-using tree-sitter sources found locally:
   $(pwd)/$src_dir

--- a/scripts/update-version-symlinks
+++ b/scripts/update-version-symlinks
@@ -26,7 +26,8 @@ mkdir -p downloads
 (
   cd downloads
   rm -f tree-sitter
-  ln -s tree-sitter-"$version" tree-sitter
+  mkdir -p tree-sitter-"$version"
+  ln -snf tree-sitter-"$version" tree-sitter
 )
 
 if [[ -d tree-sitter ]] && [[ ! -L tree-sitter ]]; then
@@ -41,5 +42,5 @@ fi
 # It allows us to use this script to switch tree-sitter versions without
 # rebuilding everything.
 rm -f tree-sitter
-ln -s tree-sitter-"$version" tree-sitter
 mkdir -p tree-sitter-"$version"
+ln -snf tree-sitter-"$version" tree-sitter


### PR DESCRIPTION
It's not possible to create dangling symlinks with native NTFS symlinks. The tar archive correctly extracts itself in the existing versioned directory.

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
