### PR TITLE
fix(windows): produce valid c_library_flags.sexp on Windows

### DIFF
--- a/scripts/ocaml-tree-sitter-gen-ocaml
+++ b/scripts/ocaml-tree-sitter-gen-ocaml
@@ -238,7 +238,7 @@ let () =
          statically against libtree-sitter to avoid problems in locating the
          library at runtime. *)
       match C.ocaml_config_var c "os_type" with
-      | Some "Win32" -> [] (* Compilation on Windows does not support rpath *)
+      | Some "Win32" -> ["()"] (* Compilation on Windows does not support rpath *)
       | _ -> ["(-Wl,-rpath,%{env:TREESITTER_LIBDIR=/usr/local/lib})"]
     in
     C.Flags.write_lines "c_library_flags.sexp" c_library_flags)


### PR DESCRIPTION
Followup to https://github.com/semgrep/ocaml-tree-sitter-core/pull/95

The c_library_flags.sexp file needs to hold an s-expression, but on windows it was being left as an empty file. As a result, builds from parsers generated with the template would fail in windows with errors like:

```
File "_build/default/OSS/languages/lisp/tree-sitter/semgrep-clojure/lib/c_library_flags.sexp", line 1, characters 0-0:
Error: no s-expression found in input
```

The fix is just to ensure we output an empty s-expression into the c_library_flags.sexp on windows.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
