### PR TITLE
fix: make parsers windows-safe for temp files

### DIFF
--- a/src/run/lib/Util_file.ml
+++ b/src/run/lib/Util_file.ml
@@ -30,6 +30,16 @@ let jsoo = ref false
    unclear.
 *)
 
+(* copied from `OSS/libs/commons/UFile.ml` *)
+(* Temporary files created using Python's [tempfile.NamedTemporaryFiles] on
+    Windows enables the [FILE_SHARE_DELETE] sharing mode. Files that have open
+    handles with the [FILE_SHARE_DELETE] sharing mode can only be re-opened in
+    that mode. To make sure we won't run into problems opening the file, we
+    add the [O_SHARE_DELETE] flag when opening all files. *)
+let win_safe_open_in_bin file : in_channel =
+  Unix.openfile file [ O_CREAT; O_RDONLY; O_SHARE_DELETE ] 0o666
+  |> Unix.in_channel_of_descr
+
 let read_file path =
   if !jsoo then (let ic = open_in_bin path in
                  let s = really_input_string ic (in_channel_length ic) in

--- a/src/run/lib/Util_file.ml
+++ b/src/run/lib/Util_file.ml
@@ -41,7 +41,7 @@ let win_safe_open_in_bin file : in_channel =
   |> Unix.in_channel_of_descr
 
 let read_file path =
-  if !jsoo then (let ic = open_in_bin path in
+  if !jsoo then (let ic = win_safe_open_in_bin path in
                  let s = really_input_string ic (in_channel_length ic) in
                  close_in ic;
                  s) else

--- a/src/run/lib/Util_file.ml
+++ b/src/run/lib/Util_file.ml
@@ -36,12 +36,11 @@ let jsoo = ref false
     handles with the [FILE_SHARE_DELETE] sharing mode can only be re-opened in
     that mode. To make sure we won't run into problems opening the file, we
     add the [O_SHARE_DELETE] flag when opening all files. *)
-let win_safe_open_in_bin file : in_channel =
+let win_safe_open_in_bin file : Unix.file_descr =
   Unix.openfile file [ O_CREAT; O_RDONLY; O_SHARE_DELETE ] 0o666
-  |> Unix.in_channel_of_descr
 
 let read_file path =
-  if !jsoo then (let ic = win_safe_open_in_bin path in
+  if !jsoo then (let ic = open_in_bin path in
                  let s = really_input_string ic (in_channel_length ic) in
                  close_in ic;
                  s) else
@@ -57,7 +56,7 @@ let read_file path =
           Buffer.add_subbytes extbuf buf 0 num_bytes;
           loop fd
     in
-    let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
+    let fd = win_safe_open_in_bin path in
     Fun.protect
       ~finally:(fun () -> Unix.close fd)
       (fun () -> loop fd)


### PR DESCRIPTION
We are getting [permission errors](https://github.com/semgrep/semgrep-proprietary/actions/runs/15644031170/job/44079163397#step:9:58) when we try to upgrade from our Menhir `js` parser for JSON to the `tree-sitter-json` parser. This seems to originate in the fact that Menhir parsers use `Parsing_helpers.tokenize_all_and_adjust_pos`, which eventually calls the `win_safe_open_in_bin` function. The `tree-sitter` parsing library just directly calls the Unix primitives, which causes permissions errors on Windows machines, [as described here.](https://github.com/semgrep/semgrep-proprietary/blob/ee2e56f595174f1469af5b5cf7e442b1562fe7b2/OSS/libs/commons/UFile.ml#L124-L131). We prefer to upgrade our runtime library for `ocaml-tree-sitter-core` to use a Windows-safe parsing method.

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
