### PR TITLE
chore: remove jsoo

### DIFF
--- a/src/run/lib/Util_file.ml
+++ b/src/run/lib/Util_file.ml
@@ -2,13 +2,6 @@
    Generic utilities not provided by OCaml.
 *)
 
-(* You should set this to true when you run code compiled by js_of_ocaml
- * so some functions can change their implementation and rely
- * less on non-portable API like Unix which does not work well under
- * node or in the browser.
-*)
-let jsoo = ref false
-
 (*
    [copied from pfff/commons/Common.ml]
 
@@ -31,10 +24,6 @@ let jsoo = ref false
 *)
 
 let read_file path =
-  if !jsoo then (let ic = open_in_bin path in
-                 let s = really_input_string ic (in_channel_length ic) in
-                 close_in ic;
-                 s) else
     let buf_len = 4096 in
     let extbuf = Buffer.create 4096 in
     let buf = Bytes.create buf_len in

--- a/src/run/lib/Util_file.mli
+++ b/src/run/lib/Util_file.mli
@@ -2,9 +2,6 @@
    Generic file utilities not provided by OCaml.
 *)
 
-(* you should set this flag when you run code compiled by js_of_ocaml *)
-val jsoo : bool ref
-
 (* Read the contents of file.
 
    This implementation works even with Linux files like /dev/fd/63


### PR DESCRIPTION
We're killing JS stuff in `semgrep`, this removes the references to the `jsoo` flag. See https://github.com/semgrep/semgrep-proprietary/pull/4081/files