### PR TITLE
chore: migrate away from GNU-style field designators

### DIFF
--- a/src/bindings/lib/bindings.c
+++ b/src/bindings/lib/bindings.c
@@ -52,21 +52,21 @@ static void finalize_tree(value v) {
 }
 
 static struct custom_operations tree_custom_ops = {
-  identifier : "tree handling",
-  finalize : finalize_tree,
-  compare : custom_compare_default,
-  hash : custom_hash_default,
-  serialize : custom_serialize_default,
-  deserialize : custom_deserialize_default
+  .identifier : "tree handling",
+  .finalize : finalize_tree,
+  .compare : custom_compare_default,
+  .hash : custom_hash_default,
+  .serialize : custom_serialize_default,
+  .deserialize : custom_deserialize_default
 };
 
 static struct custom_operations TSNode_custom_ops = {
-  identifier : "TSNode handling",
-  finalize : custom_finalize_default,
-  compare : custom_compare_default,
-  hash : custom_hash_default,
-  serialize : custom_serialize_default,
-  deserialize : custom_deserialize_default
+  .identifier : "TSNode handling",
+  .finalize : custom_finalize_default,
+  .compare : custom_compare_default,
+  .hash : custom_hash_default,
+  .serialize : custom_serialize_default,
+  .deserialize : custom_deserialize_default
 };
 
 const char *octs_read(void *payload, uint32_t byte_offset, TSPoint position,


### PR DESCRIPTION
This is not a correctness issue, but building semgrep-core currently results in a whole bunch of -Wgnu-designator warnings:

```
...
bindings.c:64:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
   64 |   identifier : "TSNode handling",
      |   ^~~~~~~~~~~~
      |   .identifier =
bindings.c:65:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
   65 |   finalize : custom_finalize_default,
      |   ^~~~~~~~~~
      |   .finalize =
bindings.c:66:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
   66 |   compare : custom_compare_default,
      |   ^~~~~~~~~
      |   .compare =
bindings.c:67:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
   67 |   hash : custom_hash_default,
      |   ^~~~~~
      |   .hash =
bindings.c:68:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
   68 |   serialize : custom_serialize_default,
      |   ^~~~~~~~~~~
      |   .serialize =
bindings.c:69:3: warning: use of GNU old-style field designator extension [-Wgnu-designator]
   69 |   deserialize : custom_deserialize_default
      |   ^~~~~~~~~~~~~
      |   .deserialize =
...
```

This patch adjusts our binding struct declarations so that do not use the old style designator convention, which squelches the warnings.

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
